### PR TITLE
Update runtime to GNOME 43

### DIFF
--- a/org.pipewire.Helvum.json
+++ b/org.pipewire.Helvum.json
@@ -1,11 +1,11 @@
 {
     "app-id": "org.pipewire.Helvum",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
-        "org.freedesktop.Sdk.Extension.llvm12"
+        "org.freedesktop.Sdk.Extension.llvm14"
     ],
     "command": "helvum",
     "finish-args": [
@@ -16,8 +16,8 @@
         "--filesystem=xdg-run/pipewire-0"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm12/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm12/lib"
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm14/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm14/lib"
     },
     "modules": [
         {


### PR DESCRIPTION
- also update llvm to 14

This bring the new 22.08 runtime with more recent Pipewire.