### PR TITLE
Make PipeWire socket read-only

### DIFF
--- a/org.pipewire.Helvum.json
+++ b/org.pipewire.Helvum.json
@@ -13,7 +13,7 @@
         "--socket=wayland",
         "--device=dri",
         "--share=ipc",
-        "--filesystem=xdg-run/pipewire-0"
+        "--filesystem=xdg-run/pipewire-0:ro"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm21/bin",


### PR DESCRIPTION
Flatpaks should not have write access to socket files, like `xdg-run/pipewire-0`. Bidirectional communication is possible regardless of the suffix, so a benevolent app sees no difference. While it shouldn't be possible in theory, it would be best to prevent the possibility of deleting or modifying the socket itself. Flathub maintainers typically request this for new submissions.

https://discourse.flathub.org/t/what-is-the-difference-if-the-pipewire-socket-is-read-only/11951/7